### PR TITLE
restrict is a reserved keyword in C99

### DIFF
--- a/hugeutils.c
+++ b/hugeutils.c
@@ -301,14 +301,14 @@ void hugetlbfs_setup_env()
 
 	env = getenv("HUGETLB_RESTRICT_EXE");
 	if (env) {
-		char *p, *tok, *exe, buf[MAX_EXE+1], restrict[MAX_EXE];
+		char *p, *tok, *exe, buf[MAX_EXE+1], restriction[MAX_EXE];
 		int found = 0;
 
 		exe = get_exe_name(buf, sizeof buf);
 		DEBUG("Found HUGETLB_RESTRICT_EXE, this exe is \"%s\"\n", exe);
-		strncpy(restrict, env, sizeof restrict);
-		restrict[sizeof(restrict)-1] = 0;
-		for (p = restrict; (tok = strtok(p, ":")) != NULL; p = NULL) {
+		strncpy(restriction, env, sizeof restriction);
+		restriction[sizeof(restriction)-1] = 0;
+		for (p = restriction; (tok = strtok(p, ":")) != NULL; p = NULL) {
 			DEBUG("  ...check exe match for \"%s\"\n",  tok);
 			if (strcmp(tok, exe) == 0) {
 				found = 1;


### PR DESCRIPTION
restrict is a reserved keyword in C99/C11, therefore it can't be used as a variable name.
This commit fix compilation with GCC 5 (which now uses -std=gnu11 as default mode instead of -std=gnu89).