### PR TITLE
Several minor cleanups v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.d
-*.o
-*.a
-*.so
 *~
+version.h
+version
+obj32
+obj64
+obj

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,4 +1,1 @@
-gethugepagesize
-test_root_hugetlbfs
-find_path
-tempfile
+shmoverride_linked.c

--- a/tests/alloc-instantiate-race.c
+++ b/tests/alloc-instantiate-race.c
@@ -111,9 +111,8 @@ struct racer_info {
 static void *thread_racer(void *info)
 {
 	struct racer_info *ri = info;
-	int rc;
 
-	rc = one_racer(ri->p, ri->cpu, ri->mytrigger, ri->othertrigger);
+	one_racer(ri->p, ri->cpu, ri->mytrigger, ri->othertrigger);
 	return ri;
 }
 static void run_race(void *syncarea, int race_type)

--- a/tests/mprotect.c
+++ b/tests/mprotect.c
@@ -63,6 +63,7 @@ static int test_read(void *p)
 	sig_expected = p;
 	barrier();
 	x = *pl;
+	verbose_printf("Read back %lu\n", x);
 	barrier();
 	sig_expected = MAP_FAILED;
 	/*

--- a/tests/shmoverride_unlinked.c
+++ b/tests/shmoverride_unlinked.c
@@ -122,7 +122,7 @@ long local_read_meminfo(const char *tag)
 	readerr = errno;
 	close(fd);
 	if (len < 0)
-		FAIL("Error reading /proc/meminfo: %s\n", strerror(errno));
+		FAIL("Error reading /proc/meminfo: %s\n", strerror(readerr));
 
 	if (len == sizeof(buf))
 		FAIL("/proc/meminfo is too large\n");


### PR DESCRIPTION
Small compile cleanups, now revised against current head.

Changes in v2:
  * Patch to remove the restrict keyword was obsoleted by a similar patch in HEAD
  * Changes for "set but not used" warnings in icache-hygeine.c were obsoleted by 4bb10df "Update for GCC 5"
