### PR TITLE
set noexec markers in the asm file directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ NODEPTARGETS=<version.h> <clean>
 
 INSTALL = install
 
-LDFLAGS += -Wl,-z,noexecstack -ldl
+LDFLAGS += -ldl
 CFLAGS ?= -O2 -g
 CFLAGS += -Wall -fPIC
 CPPFLAGS += -D__LIBHUGETLBFS__

--- a/sys-aarch64elf.S
+++ b/sys-aarch64elf.S
@@ -32,3 +32,7 @@ direct_syscall:
 	mov	x6, x7
 	svc	0x0
 	ret
+
+#if defined(__linux__) && defined(__ELF__)
+	.section .note.GNU-stack,"",%progbits
+#endif

--- a/sys-armelf_linux_eabi.S
+++ b/sys-armelf_linux_eabi.S
@@ -31,3 +31,7 @@ direct_syscall:
 	swi     0x0
 	ldmfd   sp!, {r4, r5, r6, r7}
 	bx	lr
+
+#if defined(__linux__) && defined(__ELF__)
+	.section .note.GNU-stack,"",%progbits
+#endif

--- a/sys-elf32ppclinux.S
+++ b/sys-elf32ppclinux.S
@@ -32,3 +32,7 @@ direct_syscall:
 	mr	8,9
 	sc
 	blr
+
+#if defined(__linux__) && defined(__ELF__)
+	.section .note.GNU-stack,"",%progbits
+#endif

--- a/sys-elf64_s390.S
+++ b/sys-elf64_s390.S
@@ -20,3 +20,7 @@ direct_syscall:
 	lgr	%r5,%r6
 	svc	0
 	br	%r14
+
+#if defined(__linux__) && defined(__ELF__)
+	.section .note.GNU-stack,"",%progbits
+#endif

--- a/sys-elf64ppc.S
+++ b/sys-elf64ppc.S
@@ -46,3 +46,7 @@ direct_syscall:
 	mr	8,9
 	sc
 	blr
+
+#if defined(__linux__) && defined(__ELF__)
+	.section .note.GNU-stack,"",%progbits
+#endif

--- a/sys-elf_i386.S
+++ b/sys-elf_i386.S
@@ -40,3 +40,7 @@ direct_syscall:
 	pop	%edi
 	pop	%ebp
 	ret
+
+#if defined(__linux__) && defined(__ELF__)
+	.section .note.GNU-stack,"",%progbits
+#endif

--- a/sys-elf_s390.S
+++ b/sys-elf_s390.S
@@ -20,3 +20,7 @@ direct_syscall:
 	lr	%r5,%r6
 	svc	0
 	br	%r14
+
+#if defined(__linux__) && defined(__ELF__)
+	.section .note.GNU-stack,"",%progbits
+#endif

--- a/sys-elf_x86_64.S
+++ b/sys-elf_x86_64.S
@@ -32,3 +32,7 @@ direct_syscall:
 	mov	0x8(%rsp),%r9
 	syscall
 	retq
+
+#if defined(__linux__) && defined(__ELF__)
+	.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
Using -Wl,-z,noexecstack can hide real exec stack issues coming from other
files, and is a bit unportable.  Instead, set proper section markers in the
assembly files directly.  It also means people using the static libraries
won't have to use -Wl,-z,noexecstack when they link their code.