### PR TITLE
Add AARCH64 ILP32 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,11 @@ CC64 = $(CC)
 ELF64 = aarch64elf
 TMPLIB64 = lib64
 CUSTOM_LDSCRIPTS = no
+ifneq ($(BUILDTYPE),NATIVEONLY)
+CC32 = $(CC) -mabi=ilp32
+ELF32 = aarch64elf
+TMPLIB32 = libilp32
+endif
 else
 ifneq (,$(filter i386 i486 i586 i686,$(ARCH)))
 CC32 = $(CC)


### PR DESCRIPTION
This patch adds the AARCH64 ILP32 support.
Note most of the time nativeonly should be used
as most distros don't have ILP32 support included
with them.

Signed-off-by: Andrew Pinski <apinski@cavium.com>