### PR TITLE
Tests: mark fallocate test as XFAIL before kernel 4.3.0

### DIFF
--- a/tests/fallocate_align.sh
+++ b/tests/fallocate_align.sh
@@ -7,8 +7,8 @@
 #
 compare_kvers `uname -r` "4.3.0"
 if [ $? -eq 1 ]; then
-	echo "FAIL no fallocate support in kernels before 4.3.0"
-	exit $RC_FAIL
+	echo "XFAIL no fallocate support in kernels before 4.3.0"
+	exit $RC_XFAIL
 else
 	EXP_RC=$RC_PASS
 	exec_and_check $EXP_RC fallocate_align "$@"

--- a/tests/fallocate_basic.sh
+++ b/tests/fallocate_basic.sh
@@ -7,8 +7,8 @@
 #
 compare_kvers `uname -r` "4.3.0"
 if [ $? -eq 1 ]; then
-	echo "FAIL no fallocate support in kernels before 4.3.0"
-	exit $RC_FAIL
+	echo "XFAIL no fallocate support in kernels before 4.3.0"
+	exit $RC_XFAIL
 else
 	EXP_RC=$RC_PASS
 	exec_and_check $EXP_RC fallocate_basic "$@"

--- a/tests/fallocate_stress.sh
+++ b/tests/fallocate_stress.sh
@@ -7,8 +7,8 @@
 #
 compare_kvers `uname -r` "4.3.0"
 if [ $? -eq 1 ]; then
-	echo "FAIL no fallocate support in kernels before 4.3.0"
-	exit $RC_FAIL
+	echo "XFAIL no fallocate support in kernels before 4.3.0"
+	exit $RC_XFAIL
 else
 	EXP_RC=$RC_PASS
 	exec_and_check $EXP_RC fallocate_stress "$@"


### PR DESCRIPTION
This test will fail for kernel before 4.3.0

As there is no return code for SKIP, I think it's reasonable to mark it as an
expected failure for kernel before 4.3.0

Signed-off-by: Po-Hsu Lin <po-hsu.lin@canonical.com>