### PR TITLE
ld.hugetlbfs: Add -Ttext-segment=$SLICE_SIZE for arm64

### DIFF
--- a/ld.hugetlbfs
+++ b/ld.hugetlbfs
@@ -98,6 +98,7 @@ if [ "$HTLB_ALIGN" == "slice" ]; then
 	# otherwise it will be NULL.
 	case "$EMU" in
 	armelf*_linux_eabi)	HTLBOPTS="$HTLBOPTS -Ttext-segment=$SLICE_SIZE" ;;
+	aarch64elf*|aarch64linux*)	HTLBOPTS="$HTLBOPTS -Ttext-segment=$SLICE_SIZE" ;;
 	elf_i386)		HTLBOPTS="$HTLBOPTS -Ttext-segment=0x08000000" ;;
 	esac
 fi


### PR DESCRIPTION
This patch fixes this bug.
the following test failures observed.

libhugetlbfs HUGETLB_ELFMAP_R-linkhuge_rw-2M-64 fail
libhugetlbfs HUGETLB_ELFMAP_W-HUGETLB_MINIMAL_COPY_no-linkhuge_rw-2M-64 fail
libhugetlbfs HUGETLB_ELFMAP_RW-HUGETLB_MINIMAL_COPY_no-linkhuge_rw-2M-64 fail
libhugetlbfs HUGETLB_SHARE_0-HUGETLB_ELFMAP_R-linkhuge_rw-2M-64 fail
libhugetlbfs HUGETLB_SHARE_1-HUGETLB_ELFMAP_R-linkhuge_rw-2M-64 fail

libhugetlbfs linkhuge test is failing
https://bugs.linaro.org/show_bug.cgi?id=3418

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>