### PR TITLE
Move test runner to Python3

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -303,7 +303,7 @@ def check_linkhuge_tests():
 def print_cmd(pagesize, bits, cmd, env):
     if env:
         print(' '.join(['%s=%s' % (k, v) for k, v in env.items()]), end=" ")
-    if type(cmd) != types.StringType:
+    if not isinstance(cmd, str):
         cmd = ' '.join(cmd)
     print("%s (%s: %i):\t" % (cmd, pretty_page_size(pagesize), bits), end="")
     sys.stdout.flush()

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/python2
 
 import subprocess
 import types

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -716,7 +716,7 @@ def main():
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], "vVft:b:p:c:lh")
-    except getopt.GetoptError, err:
+    except getopt.GetoptError as err:
         print(str(err))
         sys.exit(1)
     for opt, arg in opts:

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -220,7 +220,7 @@ def clear_hpages():
     cleaned up automatically and must be removed to free up the huge pages.
     """
     for mount in mounts:
-        dir = mount + "/elflink-uid-" + `os.getuid()`
+        dir = mount + "/elflink-uid-" + repr(os.getuid())
         for root, dirs, files in os.walk(dir, topdown=False):
             for name in files:
                 os.remove(os.path.join(root, name))
@@ -470,7 +470,7 @@ def setup_shm_sysctl(limit):
         sysctls[f] = fh.read()
         fh.close()
         fh = open(f, "w")
-        fh.write(`limit`)
+        fh.write(repr(limit))
         fh.close()
     print("set shmmax limit to %s" % limit)
     return sysctls

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,5 +1,7 @@
 #! /usr/bin/python2
 
+from __future__ import print_function
+
 import subprocess
 import types
 import os
@@ -60,7 +62,7 @@ def snapshot_pool_state():
 def run_test_prog(bits, pagesize, cmd, **env):
     if paranoid_pool_check:
         beforepool = snapshot_pool_state()
-        print "Pool state: %s" % str(beforepool)
+        print("Pool state: %s" % str(beforepool))
 
     local_env = os.environ.copy()
     local_env.update(env)
@@ -83,9 +85,9 @@ def run_test_prog(bits, pagesize, cmd, **env):
     if paranoid_pool_check:
         afterpool = snapshot_pool_state()
         if afterpool != beforepool:
-            print >>sys.stderr, "Hugepage pool state not preserved!"
-            print >>sys.stderr, "BEFORE: %s" % str(beforepool)
-            print >>sys.stderr, "AFTER: %s" % str(afterpool)
+            print("Hugepage pool state not preserved!", file=sys.stderr)
+            print("BEFORE: %s" % str(beforepool), file=sys.stderr)
+            print("AFTER: %s" % str(afterpool), file=sys.stderr)
             sys.exit(98)
 
     return (rc, out)
@@ -143,22 +145,24 @@ def print_per_size(title, values):
     Print the results of a given result type on one line.  The results for all
     page sizes and word sizes are written in a table format.
     """
-    print "*%20s: " % title,
+    print("*%20s: " % title, end=" ")
     for sz in pagesizes:
-        print "%4s   %4s   " % (values[sz][32], values[sz][64]),
-    print
+        print("%4s   %4s   " % (values[sz][32], values[sz][64]), end="")
+    print()
 
 def results_summary():
     """
     Display a summary of the test results
     """
-    print "********** TEST SUMMARY"
-    print "*%21s" % "",
-    for p in pagesizes: print "%-13s " % pretty_page_size(p),
-    print
-    print "*%21s" % "",
-    for p in pagesizes: print "32-bit 64-bit ",
-    print
+    print("********** TEST SUMMARY")
+    print("*%21s" % "", end=" ")
+    for p in pagesizes:
+        print("%-13s " % pretty_page_size(p), end="")
+    print()
+    print("*%21s" % "", end=" ")
+    for p in pagesizes:
+        print("32-bit 64-bit ", end="")
+    print()
 
     print_per_size("Total testcases", R["total"])
     print_per_size("Skipped", R["skip"])
@@ -170,7 +174,7 @@ def results_summary():
     print_per_size("Unexpected PASS", R["xpass"])
     print_per_size("Test not present", R["nofile"])
     print_per_size("Strange test result", R["strange"])
-    print "**********"
+    print("**********")
 
 def free_hpages():
     """
@@ -270,13 +274,13 @@ def check_hugetlbfs_path():
                 okbits.append(b)
                 mounts.append(out)
         if len(okbits) == 0:
-            print "run_tests.py: No mountpoints available for page size %s" % \
-                  pretty_page_size(p)
+            print("run_tests.py: No mountpoints available for page size %s" %
+                  pretty_page_size(p))
             wordsizes_by_pagesize[p] = set()
             continue
         for b in wordsizes - set(okbits):
-            print "run_tests.py: The %i bit word size is not compatible with " \
-                  "%s pages" % (b, pretty_page_size(p))
+            print("run_tests.py: The %i bit word size is not compatible with " \
+                  "%s pages" % (b, pretty_page_size(p)))
         wordsizes_by_pagesize[p] = set(okbits)
 
 def check_linkhuge_tests():
@@ -298,10 +302,10 @@ def check_linkhuge_tests():
 
 def print_cmd(pagesize, bits, cmd, env):
     if env:
-        print ' '.join(['%s=%s' % (k, v) for k, v in env.items()]),
+        print(' '.join(['%s=%s' % (k, v) for k, v in env.items()]), end=" ")
     if type(cmd) != types.StringType:
         cmd = ' '.join(cmd)
-    print "%s (%s: %i):\t" % (cmd, pretty_page_size(pagesize), bits),
+    print("%s (%s: %i):\t" % (cmd, pretty_page_size(pagesize), bits), end="")
     sys.stdout.flush()
 
 def run_test(pagesize, bits, cmd, **env):
@@ -321,7 +325,7 @@ def run_test(pagesize, bits, cmd, **env):
 
     print_cmd(pagesize, bits, cmd, env)
     (rc, out) = run_test_prog(bits, pagesize, cmd, **env)
-    print out
+    print(out)
 
     R["total"][pagesize][bits] += 1
     if rc == 0:    R["pass"][pagesize][bits] += 1
@@ -342,7 +346,7 @@ def skip_test(pagesize, bits, cmd, **env):
     R["total"][pagesize][bits] += 1
     R["skip"][pagesize][bits] += 1
     print_cmd(pagesize, bits, cmd, env)
-    print "SKIPPED"
+    print("SKIPPED")
 
 def do_test(cmd, bits=None, **env):
     """
@@ -468,7 +472,7 @@ def setup_shm_sysctl(limit):
         fh = open(f, "w")
         fh.write(`limit`)
         fh.close()
-    print "set shmmax limit to %s" % limit
+    print("set shmmax limit to %s" % limit)
     return sysctls
 
 def restore_shm_sysctl(sysctls):
@@ -686,17 +690,17 @@ def stress_tests():
     do_test("fallocate_stress.sh")
 
 def print_help():
-    print "Usage: %s [options]" % sys.argv[0]
-    print "Options:"
-    print "  -v	\t Verbose output."
-    print "  -V	\t Highly verbose output."
-    print "  -f	\t Force all tests."
-    print "  -t <set> 	 Run test set, allowed are func and stress."
-    print "  -b <wordsize>  Define wordsizes to be used. "
-    print "  -p <pagesize>  Define the page sizes to be used."
-    print "  -c	\t Do a paranoid pool check."
-    print "  -l	\t Use custom ld scripts."
-    print "  -h	\t This help."
+    print("Usage: %s [options]" % sys.argv[0])
+    print("Options:")
+    print("  -v	\t Verbose output.")
+    print("  -V	\t Highly verbose output.")
+    print("  -f	\t Force all tests.")
+    print("  -t <set> 	 Run test set, allowed are func and stress.")
+    print("  -b <wordsize>  Define wordsizes to be used. ")
+    print("  -p <pagesize>  Define the page sizes to be used.")
+    print("  -c	\t Do a paranoid pool check.")
+    print("  -l	\t Use custom ld scripts.")
+    print("  -h	\t This help.")
     sys.exit(0)
 
 def main():
@@ -713,7 +717,7 @@ def main():
     try:
         opts, args = getopt.getopt(sys.argv[1:], "vVft:b:p:c:lh")
     except getopt.GetoptError, err:
-        print str(err)
+        print(str(err))
         sys.exit(1)
     for opt, arg in opts:
        if opt == "-v":
@@ -742,8 +746,8 @@ def main():
     if len(pagesizes) == 0: pagesizes = get_pagesizes()
 
     if len(pagesizes) == 0:
-        print "Unable to find available page sizes, are you sure hugetlbfs"
-        print "is mounted and there are available huge pages?"
+        print("Unable to find available page sizes, are you sure hugetlbfs")
+        print("is mounted and there are available huge pages?")
         return 1
 
     setup_env(env_override, env_defaults)
@@ -751,8 +755,8 @@ def main():
 
     (rc, system_default_hpage_size) = hpage_size()
     if rc != 0:
-        print "Unable to find system default hugepage size."
-        print "Is hugepage supported included in this kernel?"
+        print("Unable to find system default hugepage size.")
+        print("Is hugepage supported included in this kernel?")
         return 1
 
     check_hugetlbfs_path()

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python2
+#! /usr/bin/python3
 
 from __future__ import print_function
 from __future__ import division

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -48,7 +48,7 @@ def bash(cmd):
     except KeyboardInterrupt:
         # Abort and mark this a strange test result
         return (127, "")
-    out = p.stdout.read().strip()
+    out = p.stdout.read().decode().strip()
     return (rc, out)
 
 def snapshot_pool_state():
@@ -80,7 +80,7 @@ def run_test_prog(bits, pagesize, cmd, **env):
         return (None, "")
     except OSError as e:
         return (-e.errno, "")
-    out = p.stdout.read().strip()
+    out = p.stdout.read().decode().strip()
 
     if paranoid_pool_check:
         afterpool = snapshot_pool_state()
@@ -241,9 +241,11 @@ def get_pagesizes():
     sizes = set()
     out = ""
     (rc, out) = bash("../obj/hugeadm --page-sizes")
-    if rc != 0 or out == "": return sizes
+    if rc != 0 or out == "":
+        return sizes
 
-    for size in out.split("\n"): sizes.add(int(size))
+    for size in out.split("\n"):
+        sizes.add(int(size))
     return sizes
 
 def get_wordsizes():

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,6 +1,7 @@
 #! /usr/bin/python2
 
 from __future__ import print_function
+from __future__ import division
 
 import subprocess
 import types
@@ -684,7 +685,7 @@ def stress_tests():
     # This is to catch off-by-ones or races in the kernel allocated that
     # can make allocating all hugepages a problem
     if nr_pages > 1:
-        do_shm_test(("shm-fork", repr(threads), repr(nr_pages / 2)), limit)
+        do_shm_test(("shm-fork", repr(threads), repr(nr_pages // 2)), limit)
     do_shm_test(("shm-fork", repr(threads), repr(nr_pages)), limit)
 
     do_shm_test(("shm-getraw", repr(nr_pages), "/dev/full"), limit)


### PR DESCRIPTION
Python2 has been end-of-life for a while now.  This makes some changes to switch the libhugetlbfs test runner script to Python3 for easier use on modern systems.
