### PR TITLE
Add riscv64 hugepage parameter setup on --hugetlbfs-align

### DIFF
--- a/elflink.c
+++ b/elflink.c
@@ -1207,7 +1207,7 @@ static int set_hpage_sizes(const char *env)
 						strerror(errno));
 			size = 0;
 		} else if (!hugetlbfs_find_path_for_size(size)) {
-			WARNING("Hugepage size %li unavailable", size);
+			WARNING("Hugepage size %li unavailable\n", size);
 			size = 0;
 		}
 

--- a/ld.hugetlbfs
+++ b/ld.hugetlbfs
@@ -92,17 +92,6 @@ if [ -z "$EMU" ]; then
 	fi
 fi
 
-# if -m is not present on command line
-if [ -z "$EMU" ]; then
-	if [ -n "$LDEMULATION" ]; then
-		# try env. variable
-		EMU="$LDEMULATION"
-	else
-		# pick first supported
-		EMU="$(ld -V | sed -n '/Supported emulations/{n;p}' | tr -d ' ')"
-	fi
-fi
-
 MB=$((1024*1024))
 case "$EMU" in
 elf32ppclinux)		HPAGE_SIZE=$((16*$MB)) SLICE_SIZE=$((256*$MB)) ;;
@@ -115,6 +104,8 @@ elf64ppc|elf64lppc)
 	else
 		SLICE_SIZE=$HPAGE_SIZE
 	fi ;;
+
+elf64lriscv*)           HPAGE_SIZE=$((2*$MB)) SLICE_SIZE=$HPAGE_SIZE ;;
 elf_i386|elf_x86_64)	HPAGE_SIZE=$((4*$MB)) SLICE_SIZE=$HPAGE_SIZE ;;
 elf_s390|elf64_s390)	HPAGE_SIZE=$((1*$MB)) SLICE_SIZE=$HPAGE_SIZE ;;
 armelf*_linux_eabi|aarch64elf*|aarch64linux*)
@@ -134,6 +125,7 @@ if [ "$HTLB_ALIGN" == "slice" ]; then
 		printf -v TEXTADDR "%x" "$SLICE_SIZE"
 		HTLBOPTS="$HTLBOPTS -Ttext-segment=$TEXTADDR" ;;
 	elf_i386)		HTLBOPTS="$HTLBOPTS -Ttext-segment=0x08000000" ;;
+	elf64lriscv*)   HTLBOPTS="-Ttext-segment=0x200000 $HTLBOPTS" ;;
 	elf64ppc|elf64lppc)
 		if [ "$MMU_TYPE" == "Hash" ] ; then
 			printf -v TEXTADDR "%x" "$SLICE_SIZE"

--- a/morecore.c
+++ b/morecore.c
@@ -332,7 +332,7 @@ void hugetlbfs_setup_morecore(void)
 		heap_fd = -1;
 	} else {
 		if (!hugetlbfs_find_path_for_size(hpage_size)) {
-			WARNING("Hugepage size %li unavailable", hpage_size);
+			WARNING("Hugepage size %li unavailable\n", hpage_size);
 			return;
 		}
 


### PR DESCRIPTION
Add parameter setting in the linker wrapper script for riscv64 2MB page, slice size and start-segment address change (from 0x10000 default to 0x200000 alignment when --hugetlbfs-align is specified).