### PR TITLE
Call clean_hpages() before checking the pool state.

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -84,6 +84,7 @@ def run_test_prog(bits, pagesize, cmd, **env):
     out = p.stdout.read().decode().strip()
 
     if paranoid_pool_check:
+        clear_hpages()
         afterpool = snapshot_pool_state()
         if afterpool != beforepool:
             print("Hugepage pool state not preserved!", file=sys.stderr)


### PR DESCRIPTION
Without the __morecore glibc symbol existing, one instance of linkhuge_rw dies with a segfault, leaving behind a file in /dev/hugepages/elflink-uid-0.

This trips up the paranoid pool check, and terminates the test run. Removing the stale hugetlbfs file fixes that.