### PR TITLE
tests: Fix bug in paranoid bug

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -55,8 +55,11 @@ def bash(cmd):
 def snapshot_pool_state():
     l = []
     for d in os.listdir("/sys/kernel/mm/hugepages"):
-        substate = [(f, int(open("/sys/kernel/mm/hugepages/%s/%s" % (d, f)).read()))
-                    for f in os.listdir("/sys/kernel/mm/hugepages/%s" % d)]
+        entries = os.listdir("/sys/kernel/mm/hugepages/%s" % d)
+        if "demote" in entries:
+            entries.remove("demote")
+        substate = [(f, int(open("/sys/kernel/mm/hugepages/%s/%s" % (d, f)).read().replace("kB","")))
+                    for f in entries]
         l.append((d, tuple(substate)))
     return tuple(l)
 


### PR DESCRIPTION
It is impossible to run this test in newer kernels due to 2 bugs:

1) New kernels has some values with "kB"
2) New kernel has an entry ("demote") that the test doesn't have permission to read

Fix both cases by removing "kB" from the value, and do not touch the "demote" file.