### PR TITLE
Fix bug in minimal copy optimization: keep STB_GNU_UNIQUE symbols

### DIFF
--- a/elflink.c
+++ b/elflink.c
@@ -436,7 +436,7 @@ static int find_numsyms(Elf_Sym *symtab, char *strtab)
  * symbols based on information in the dynamic section. The following
  * characteristics apply to symbols which may require copying:
  * - Within the BSS
- * - Global or Weak binding
+ * - Global, Weak, or GNU Unique binding
  * - Object type (variable)
  * - Non-zero size (zero size means the symbol is just a marker with no data)
  */
@@ -447,7 +447,8 @@ static inline int keep_symbol(char *strtab, Elf_Sym *s, void *start, void *end)
 	if ((void *)s->st_value > end)
 		return 0;
 	if ((ELF_ST_BIND(s->st_info) != STB_GLOBAL) &&
-	    (ELF_ST_BIND(s->st_info) != STB_WEAK))
+		(ELF_ST_BIND(s->st_info) != STB_WEAK) &&
+		(ELF_ST_BIND(s->st_info) != STB_GNU_UNIQUE))
 		return 0;
 	if (ELF_ST_TYPE(s->st_info) != STT_OBJECT)
 		return 0;


### PR DESCRIPTION
The minimal copy optimization incorrectly ignores `STB_GNU_UNIQUE` symbols.

This causes `STB_GNU_UNIQUE` symbols to not be copied correctly if they’re after the highest “kept symbol” in a binary.

```
| [ symbol_1 ] [ unique_symbol ] [symbol_2] | --> Unique symbol will be copied correctly
| [ symbol_1 ] [symbol_2] [ unique_symbol ] | --> Unique symbol will *not* be copied correctly
```  

This can cause (among other issues) C++ locale-based parsing involving `std::numpunct` (https://en.cppreference.com/w/cpp/locale/numpunct) to fail in unexpected ways (as it can rely on `STB_GNU_UNIQUE` unique symbols):

```
$ readelf -W -s ./repro --demangle | grep 'Num\|UNIQUE' 
   Num:    Value          Size Type    Bind   Vis      Ndx Name
   739: 00000000005a14d0     8 OBJECT  UNIQUE DEFAULT   32 std::__cxx11::numpunct<char>::id
```

This patch updates `keep_symbols` to keep `STB_GNU_UNIQUE` symbols. Note that `keep_symbols` appears to predate the introduction of `STB_GNU_UNIQUE` by several years.  


A temporary workaround for anyone else with this issue is to set the environment variable `HUGETLB_MINIMAL_COPY=no` to bypass the minimal copy optimization all together.