### PR TITLE
Add support for loongarch64 architecture in ld.hugetlbfs

### DIFF
--- a/ld.hugetlbfs
+++ b/ld.hugetlbfs
@@ -117,6 +117,7 @@ elf64ppc|elf64lppc)
 	fi ;;
 elf_i386|elf_x86_64)	HPAGE_SIZE=$((4*$MB)) SLICE_SIZE=$HPAGE_SIZE ;;
 elf_s390|elf64_s390)	HPAGE_SIZE=$((1*$MB)) SLICE_SIZE=$HPAGE_SIZE ;;
+elf64loongarch)         HPAGE_SIZE=$((32*$MB)) SLICE_SIZE=$HPAGE_SIZE ;;
 armelf*_linux_eabi|aarch64elf*|aarch64linux*)
 	hpage_kb=$(cat /proc/meminfo  | grep Hugepagesize: | awk '{print $2}')
 	HPAGE_SIZE=$((hpage_kb * 1024))


### PR DESCRIPTION
- Added alignment configuration for loongarch64 architecture in the `ld.hugetlbfs` script.
- Set `HPAGE_SIZE` to 32MB and `SLICE_SIZE` to match `HPAGE_SIZE` for loongarch64.
- This ensures correct alignment and hugepage usage for binaries targeting loongarch64 systems.

Fix: https://github.com/libhugetlbfs/libhugetlbfs/issues/91
Reference: https://github.com/llvm/llvm-project/blob/main/lld/ELF/Driver.cpp#L217

![微信截图_20240927151502](https://github.com/user-attachments/assets/b873d700-a7b9-4ae6-ac46-43bd88fb923d)
