### PR TITLE
tests/icache-hygiene: Add LoongArch64 support for SIGILL handling

### DIFF
--- a/tests/icache-hygiene.c
+++ b/tests/icache-hygiene.c
@@ -94,9 +94,15 @@ static void sig_handler(int signum, siginfo_t *si, void *uc)
 	 * instruction, so, if the icache is cleared properly, we SIGILL
 	 * as soon as we jump into the cleared page */
 	if (signum == SIGILL) {
-		verbose_printf("SIGILL at %p (sig_expected=%p)\n", si->si_addr,
-			       sig_expected);
-		if (si->si_addr == sig_expected) {
+		void *pc;
+#if defined(__loongarch64)
+		ucontext_t *uc = (ucontext_t *)ucontext;
+		pc = (void *)uc->uc_mcontext.__pc;
+#else
+		pc = si->si_addr;
+#endif
+		verbose_printf("SIGILL at %p (sig_expected=%p)\n", pc, sig_expected);
+		if (pc == sig_expected) {
 			siglongjmp(sig_escape, 1);
 		}
 		FAIL("SIGILL somewhere unexpected");


### PR DESCRIPTION
- Add __loongarch64 to arch detection for instruction cache tests
- Fetch PC from ucontext's __pc field instead of si_addr on LoongArch64
- Align handling with existing architectures (PowerPC, AArch64, etc)
- Maintain original si_addr behavior for other platforms

This matches the pattern used by other architectures where the faulting
address needs to be explicitly retrieved from the CPU context registers
rather than relying on si_addr.

Fix: https://github.com/libhugetlbfs/libhugetlbfs/issues/99