### PR TITLE
elflink.c: Fix HUGETLB_FORCE_ELFMAP partial segment remapping

### DIFF
--- a/elflink.c
+++ b/elflink.c
@@ -785,7 +785,7 @@ int parse_elf_partial(struct dl_phdr_info *info, size_t size, void *data)
 		vaddr = hugetlb_next_slice_start(info->dlpi_addr +
 						 info->dlpi_phdr[i].p_vaddr);
 		gap = vaddr - (info->dlpi_addr + info->dlpi_phdr[i].p_vaddr);
-		slice_end = hugetlb_slice_end(vaddr);
+		slice_end = hugetlb_slice_end(vaddr + 1);
 		/*
 		 * we should stop remapping just before the slice
 		 * containing the end of the memsz portion (taking away
@@ -805,7 +805,7 @@ int parse_elf_partial(struct dl_phdr_info *info, size_t size, void *data)
 					i, memsz, slice_end - vaddr);
 			continue;
 		}
-		memsz = hugetlb_prev_slice_end(vaddr + memsz) - vaddr;
+		memsz = hugetlb_prev_slice_end(vaddr + memsz) - vaddr + 1;
 
 		if (save_phdr(htlb_num_segs, i, info->dlpi_addr,
 			      &info->dlpi_phdr[i]))
@@ -822,6 +822,7 @@ int parse_elf_partial(struct dl_phdr_info *info, size_t size, void *data)
 		htlb_seg_table[htlb_num_segs].vaddr = (void *)vaddr;
 		htlb_seg_table[htlb_num_segs].filesz = memsz;
 		htlb_seg_table[htlb_num_segs].memsz = memsz;
+		htlb_seg_table[htlb_num_segs].page_size = hpage_readonly_size;
 
 		htlb_num_segs++;
 	}


### PR DESCRIPTION
HUGETLB_FORCE_ELFMAP was failing to remap segments due to multiple bugs in parse_elf_partial():

1. slice_end was incorrectly calculated using hugetlb_slice_end(vaddr) where vaddr is already at a slice boundary, resulting in slice_end being equal to vaddr. This caused all segments to be rejected as "too small" (slice_end - vaddr = 0xffffffffffffffff due to underflow).

2. htlb_seg_table[htlb_num_segs].page_size was left uninitialized, which could cause undefined behavior during remapping.

3. The memsz calculation had an off-by-one error, causing the remapped segment to be one byte short of the required size.

Fix by:
- Using hugetlb_slice_end(vaddr + 1) to get the actual end of the slice
- Initializing page_size to hpage_readonly_size
- Adding 1 to the memsz calculation to include the last byte

With these fixes, HUGETLB_FORCE_ELFMAP correctly identifies and remaps eligible segments to hugepages.

Tested with: HUGETLB_ELFMAP=R HUGETLB_FORCE_ELFMAP=yes