### PR TITLE
build: Update HOWTO to reflect changes made in #86

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -178,7 +178,11 @@ the mountpoint need to be set appropriately.
 Installation
 ============
 
-1. Type "make" to build the library
+1. Use autotools to build the library:
+
+       ./autogen.sh
+       ./configure
+       make
 
 This will create "obj32" and/or "obj64" under the top level
 libhugetlbfs directory, and build, respectively, 32-bit and 64-bit
@@ -187,7 +191,8 @@ directory.  This will also build (but not run) the testsuite.
 
 On i386 systems, only the 32-bit library will be built.  On PowerPC
 and AMD64 systems, both 32-bit and 64-bit versions will be built (the
-32-bit AMD64 version is identical to the i386 version).
+32-bit AMD64 version is identical to the i386 version) unless the
+BUILDTYPE=NATIVEONLY variable is set when running "make".
 
 2. Run the testsuite with "make check"
 


### PR DESCRIPTION
The commit 3a9d51c107e1 adds autotools support but the build instructions in HOWTO still assume a Makefile is ready at the root of the directory. This commit adds the autotools build instructions documented in the commit to the HOWTO.

I did read through [the contribution guidelines](https://github.com/libhugetlbfs/libhugetlbfs/blob/166588f8015fcf01a12230b31db584391132673e/SubmittingCode) but noticed that GitHub PRs have been accepted recently. I went for a GitHub PR because I'm not familiar with submitting patches via a mailing list.