### PR TITLE
Add missing '\n' newline characters to WARNING messages

### DIFF
--- a/elflink.c
+++ b/elflink.c
@@ -933,7 +933,7 @@ static int fork_and_prepare_segment(struct seg_info *htlb_seg_info)
 	int pid, ret, status;
 
 	if ((pid = fork()) < 0) {
-		WARNING("fork failed");
+		WARNING("fork failed\n");
 		return -1;
 	}
 	if (pid == 0) {
@@ -947,7 +947,7 @@ static int fork_and_prepare_segment(struct seg_info *htlb_seg_info)
 	}
 	ret = waitpid(pid, &status, 0);
 	if (ret == -1) {
-		WARNING("waitpid failed");
+		WARNING("waitpid failed\n");
 		return -1;
 	}
 
@@ -1209,7 +1209,7 @@ static int set_hpage_sizes(const char *env)
 						strerror(errno));
 			size = 0;
 		} else if (!hugetlbfs_find_path_for_size(size)) {
-			WARNING("Hugepage size %li unavailable", size);
+			WARNING("Hugepage size %li unavailable\n", size);
 			size = 0;
 		}
 
@@ -1232,7 +1232,7 @@ static int check_env(void)
 		return -1;
 	}
 	if (__hugetlb_opts.elfmap && set_hpage_sizes(__hugetlb_opts.elfmap)) {
-		WARNING("Cannot set elfmap page sizes: %s", strerror(errno));
+		WARNING("Cannot set elfmap page sizes: %s\n", strerror(errno));
 		return -1;
 	}
 
@@ -1322,7 +1322,7 @@ void hugetlbfs_setup_elflink(void)
 
 		ret = find_or_create_share_path(page_size);
 		if (ret != 0) {
-			WARNING("Segment remapping is disabled");
+			WARNING("Segment remapping is disabled\n");
 			return;
 		}
 	}

--- a/hugeadm.c
+++ b/hugeadm.c
@@ -707,7 +707,7 @@ void create_mounts(char *user, char *group, char *base, mode_t mode)
 			if (maxlen > strlen(limits))
 				strcat(options, limits);
 			else
-				WARNING("String limitations met, cannot append limitations onto mount options string. Increase OPT_MAX");
+				WARNING("String limitations met, cannot append limitations onto mount options string. Increase OPT_MAX\n");
 		}
 
 		if (ensure_dir(path, mode, uid, gid)) {
@@ -774,7 +774,7 @@ long recommended_minfreekbytes(void)
 	/* Detect the number of zones in the system */
 	f = fopen(PROCZONEINFO, "r");
 	if (f == NULL) {
-		WARNING("Unable to open " PROCZONEINFO);
+		WARNING("Unable to open " PROCZONEINFO "\n");
 		return 0;
 	}
 	while (fgets(buf, ZONEINFO_LINEBUF, f) != NULL) {

--- a/morecore.c
+++ b/morecore.c
@@ -339,7 +339,7 @@ void hugetlbfs_setup_morecore(void)
 		heap_fd = -1;
 	} else {
 		if (!hugetlbfs_find_path_for_size(hpage_size)) {
-			WARNING("Hugepage size %li unavailable", hpage_size);
+			WARNING("Hugepage size %li unavailable\n", hpage_size);
 			return;
 		}
 


### PR DESCRIPTION
A number of WARNING messages were missing trailing '\n' newline characters, which can result in user output being emitted on the same line as WARNING messages.  Based on other WARNING messages, the intent appears to be to include a trailing '\n' newline, so add them where missing.  This issue was observed for the "Hugepage size %li unavailable" WARNING message.